### PR TITLE
fix: #5: html langAttribute の欠落による警告の解消

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  i18n: {
+    locales: ["ja"],
+    defaultLocale: "ja",
+  },
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
`lang="ja"` にする